### PR TITLE
fix: Add required OAuth metadata fields for pre-configured OAuth clients

### DIFF
--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -182,6 +182,9 @@ export class MCPOAuthHandler {
           token_endpoint: config.token_url,
           issuer: serverUrl,
           scopes_supported: config.scope?.split(' '),
+          response_types_supported: ['code'],
+          code_challenge_methods_supported: ['S256'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
         };
 
         const clientInfo: OAuthClientInformation = {


### PR DESCRIPTION
This will allow us to configure clients manually until we have ToolHive support for dynamic discovery. That requires fixing ToolHive as well as fixing librechat which currently ties authorization server discovery with client registration and allows to either do both or none - and Google doesn't support dynamic client discovery.

When using pre-configured OAuth settings (client_id, authorization_url, token_url), the manually constructed metadata object was missing required fields that the MCP SDK validates in startAuthorization():

https://github.com/modelcontextprotocol/typescript-sdk/blob/31acdcbb189056ec83d14a4f7a37ae2b1c67680e/src/client/auth.ts#L820

Add the missing required fields with MCP-compliant values:
- response_types_supported: ['code']
- code_challenge_methods_supported: ['S256']
- grant_types_supported: ['authorization_code', 'refresh_token']

Dynamic discovery path is unaffected as discoverAuthorizationServerMetadata() returns complete metadata from the OAuth provider.
