### PR TITLE
fix: corrects mount directory for mongodb

### DIFF
--- a/helm/librechat/stacklok_combined_values.yaml
+++ b/helm/librechat/stacklok_combined_values.yaml
@@ -207,6 +207,8 @@ mongodb:
     enabled: false
   databases:
    - LibreChat
+  persistence:
+    mountPath: /data/db
   image:
     registry: 781189302813.dkr.ecr.us-east-1.amazonaws.com
     repository: mongodb
@@ -219,6 +221,7 @@ mongodb:
     enabled: true
     fsGroup: 999
     runAsUser: 999
+
   extraEnvVars:
     - name: MONGODB_DATA_DIR
       value: /bitnami/mongodb


### PR DESCRIPTION
The PVC was being mounted to `/bitnami/mongodb` instead of `/data/db`. This PR fixes this so we can retain the data when the pod restarts.